### PR TITLE
Add shell=True to subprocess

### DIFF
--- a/dagon.py
+++ b/dagon.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     if len(sys.argv) <= 1:
         LOGGER.fatal("You have failed to provide a flag to the application and have been redirected to the help menu.")
         time.sleep(1.7)
-        subprocess.call("python dagon.py --help")
+        subprocess.call("python dagon.py --help", shell=True)
     else:
         try:
             # Download a random wordlist
@@ -237,7 +237,7 @@ if __name__ == '__main__':
             # You never provided a mandatory argument
             else:
                 LOGGER.fatal("Missing mandatory argument, redirecting to help menu..")
-                subprocess.call("python dagon.py --help")
+                subprocess.call("python dagon.py --help", shell=True)
 
         # Why you gotta interrupt my awesome?
         except KeyboardInterrupt:


### PR DESCRIPTION
Before: 
`[09:07:10 CRITICAL] You have failed to provide a flag to the application and have been redirected to the help menu.
Traceback (most recent call last):
  File "dagon.py", line 119, in <module>
    subprocess.call("python dagon.py --help")
  File "/usr/lib/python2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1024, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
`
After: 
`[09:09:17 CRITICAL] You have failed to provide a flag to the application and have been redirected to the help menu.
Usage: dagon [c|v|l] HASH|HASH|HASH-LIST --bruteforce [OPTS]

Options:
  -h, --help            show this help message and exit`
