### PR TITLE
Convert `testchar` to integer using `ord(testchar)`

### DIFF
--- a/thirdparty/blake/blake_test.py
+++ b/thirdparty/blake/blake_test.py
@@ -232,7 +232,7 @@ if have_blake and have_blake_wrapper:
                     BLAKEwrap(hashsize).final(testchar * i)):
                 errors += 1
                 print('      *** blake.py and blake_wrapper.py' +
-                      ' do not agree for chr(%d)*%d ***' % (testchar, i))
+                      ' do not agree for chr(%d)*%d ***' % (ord(testchar), i))
         if not errors:
             print('      no errors found')
 


### PR DESCRIPTION
There seems to be a `TypeError` raised because `testchar` is not an integer. Using `ord(testchar)` seems to fix the issue.

```python
print('      *** blake.py and blake_wrapper.py' +
                      ' do not agree for chr(%d)*%d ***' % (testchar, i))
                                                            ^^^^^^^^
>>> testchar = b'\xff'
>>> 'chr(%d)' % testchar
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: %d format: a number is required, not str
>>> ord(testchar)
255
>>> chr(ord(testchar)) == testchar
True
>>> 'chr(%d)' % ord(testchar)
'chr(255)'

```