### PR TITLE
Use `is not None` instead of `!= None`

### DIFF
--- a/thirdparty/md2/md2_hash.py
+++ b/thirdparty/md2/md2_hash.py
@@ -86,7 +86,7 @@ class MD2(object):
         self.buf = []
         self.c = [0] * digest_size
         self.d = [0] * (3 * digest_size)
-        if (m != None):
+        if (m is not None):
             self.update(m)
 
     def update(self, m):


### PR DESCRIPTION
> ["Comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators."](https://pep8.org/#programming-recommendations)
