### PR TITLE
Simplify `algorithm_pointers`

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -331,18 +331,13 @@ def show_available_algs(show_all=False, supp="+", not_yet="-", spacer1=" "*5, sp
 
 def algorithm_pointers(pointer_identity):
     """ Point to the correct algorithm given by an identification number """
-    if pointer_identity is None:
-        pass
-    else:
-        try:
-            if int(pointer_identity) in IDENTIFICATION.keys():
-                return IDENTIFICATION[int(pointer_identity)]
-            else:
-                LOGGER.fatal("The algorithm identification number you have specified is invalid.")
-                LOGGER.debug("Valid identification numbers are: {}".format(IDENTIFICATION))
-        except ValueError:
-            LOGGER.fatal("The algorithm identification number you have specified is invalid.")
-            LOGGER.debug("Valid identification numbers are: {}".format(IDENTIFICATION))
+    try:
+        return IDENTIFICATION[int(pointer_identity)]
+    except TypeError:
+        return None
+    except (KeyError, ValueError):
+        LOGGER.fatal("The algorithm identification number you have specified is invalid.")
+        LOGGER.debug("Valid identification numbers are: {}".format(IDENTIFICATION))
 
 
 def integrity_check(url="https://raw.githubusercontent.com/Ekultek/Dagon/master/md5sum/checksum.md5",


### PR DESCRIPTION
In your original function, `if pointer_identity is None` the function will return `None`. This can be simplified by knowing that a `TypeError` will be raised for `int(None)`

```python
>>> int(None)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: int() argument must be a string or a number, not 'NoneType'

```
In your original function, the exact same messages are logged if either the key doesn't exist in `IDENTIFICATION` or if a `ValueError` is raised. This can also be simplified by checking for a `KeyError`.

```python
>>> IDENTIFICATION = {100: "md5", 110: "md2", 120: "md4"}
>>> IDENTIFICATION[99]
Traceback (most recent call last):
  File "<input>", line 1, in <module>
KeyError: 99

```
The simplified code looks like this:

```python
def algorithm_pointers(pointer_identity):
    """ Point to the correct algorithm given by an identification number """
    try:
        return IDENTIFICATION[int(pointer_identity)]
    except TypeError:
        return None
    except (KeyError, ValueError):
        LOGGER.fatal("The algorithm identification number you have specified is invalid.")
        LOGGER.debug("Valid identification numbers are: {}".format(IDENTIFICATION))

```
One last thing. Some people don't like the above style of one line that can throw multiple errors then returning inside of a try/except because the tracebacks may not be as obvious. For example, here is a version which might alleviate those concerns.

```python
def algorithm_pointers(pointer_identity):
    """ Point to the correct algorithm given by an identification number """
    try:
        key = int(pointer_identity)
        algorithm = IDENTIFICATION[key]
    except TypeError:
        return None
    except (KeyError, ValueError):
        LOGGER.fatal("The algorithm identification number you have specified is invalid.")
        LOGGER.debug("Valid identification numbers are: {}".format(IDENTIFICATION))
    else:
        return algorithm

```
If there was a different error raised, it might be more obvious where it came from (either the `key =` line or the `algorithm =` line.

For this simple of an example, I tend to think the first version works just fine but it's up to you.
