### PR TITLE
Remove need for urllib2 by using requests

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,14 +1,12 @@
-import re
-import sys
 import logging
-import time
+import re
 import string
-try:
-    import urllib2
-except ImportError:  # Compatible with Python 3.x
-    import urllib as urllib2
+import sys
+import time
+
 import requests
 from colorlog import ColoredFormatter
+
 from lib.algorithms.hashing_algs import *
 
 # Create logging
@@ -345,7 +343,7 @@ def integrity_check(url="https://raw.githubusercontent.com/Ekultek/Dagon/master/
                     path="{}/md5sum/checksum.md5"):
     """ Check the integrity of the program """
     LOGGER.info("Checking program integrity...")
-    if open(path.format(os.getcwd())).read() == urllib2.urlopen(url).read():
+    if open(path.format(os.getcwd())).read() == requests.get(url).text:
         pass
     else:
         checksum_fail = "MD5 sums did not match from origin master, "


### PR DESCRIPTION
I think `urllib2` can be safely removed because `requests` is already in `requirements.txt` and is imported in `settings.py` too.

```python
>>> import os
>>> import requests
>>> import urllib2
>>> url = "https://raw.githubusercontent.com/Ekultek/Dagon/master/md5sum/checksum.md5"
>>> one = urllib2.urlopen(url).read()
>>> two = requests.get(url).text
>>> one == two
True
>>> path = "{}/md5sum/checksum.md5"
>>> file_md5 = open(path.format(os.getcwd())).read()
>>> one == two == file_md5
True

```

I also optimized the imports (one click in PyCharm) so they adhere to PEP8.

> Imports should be grouped in the following order:
> 1. standard library imports
> 2. related third party imports
> 3. local application/library specific imports

https://pep8.org/#imports
