### PR TITLE
Reorder imports (standard, third-party, local)

### DIFF
--- a/bin/attacks/bruteforce/bf_attack.py
+++ b/bin/attacks/bruteforce/bf_attack.py
@@ -1,15 +1,17 @@
-import os
 import itertools
+import os
 
 from bin.verify_hashes.verify import verify_hash_type
-from lib.settings import FUNC_DICT
-from lib.settings import LOGGER
-from lib.settings import DAGON_ISSUE_LINK
-from lib.settings import WORDLIST_RE
-from lib.settings import match_found
-from lib.settings import prompt
-from lib.settings import shutdown
-from lib.settings import random_salt_generator
+from lib.settings import (
+    DAGON_ISSUE_LINK,
+    FUNC_DICT,
+    LOGGER,
+    WORDLIST_RE,
+    match_found,
+    prompt,
+    random_salt_generator,
+    shutdown
+)
 
 # The name of the wordlist
 WORDLIST_NAME = "Dagon-bfdict-" + random_salt_generator(use_string=True, length=7)[0] + ".txt"

--- a/bin/verify_hashes/verify.py
+++ b/bin/verify_hashes/verify.py
@@ -1,8 +1,10 @@
 import re
-from lib.settings import shutdown
-from lib.settings import LOGGER
-from lib.settings import DAGON_ISSUE_LINK
 
+from lib.settings import (
+    DAGON_ISSUE_LINK,
+    LOGGER,
+    shutdown
+)
 
 # Has to be the first function so I can use it in the regex
 def build_re(hex_len, prefix=r"", suffix=r"(:.+)?"):

--- a/dagon.py
+++ b/dagon.py
@@ -1,29 +1,31 @@
 #! usr/bin/env python
 
+import optparse
 import os
+import random
+import subprocess
 import sys
 import time
-import random
-import optparse
-import subprocess
 
-from lib.settings import CLONE
-from lib.settings import prompt
-from lib.settings import LOGGER
-from lib.settings import match_found
-from lib.settings import show_banner
-from lib.settings import update_system
-from lib.settings import VERSION_STRING
-from lib.settings import integrity_check
-from lib.settings import start_up, shutdown
-from lib.settings import algorithm_pointers
-from lib.settings import show_hidden_banner
-from lib.settings import show_available_algs
-from lib.settings import random_salt_generator
-from lib.settings import verify_python_version
-from lib.settings import download_rand_wordlist
-from bin.verify_hashes.verify import verify_hash_type
 from bin.attacks.bruteforce.bf_attack import bruteforce_main
+from bin.verify_hashes.verify import verify_hash_type
+from lib.settings import (
+    CLONE,
+    LOGGER,
+    VERSION_STRING,
+    algorithm_pointers,
+    download_rand_wordlist,
+    integrity_check,
+    match_found,
+    prompt,
+    random_salt_generator,
+    show_available_algs,
+    show_banner,
+    show_hidden_banner,
+    start_up, shutdown,
+    update_system,
+    verify_python_version
+)
 
 if __name__ == '__main__':
 

--- a/lib/algorithms/hashing_algs.py
+++ b/lib/algorithms/hashing_algs.py
@@ -1,16 +1,18 @@
-import os
+import base64
+import binascii
 import hashlib
+import os
 import random
 import zlib
-import lib
-import binascii
-import base64
+
 import sha3
 from passlib.hash import bcrypt
 from thirdparty.blake import blake
+from thirdparty.des import pydes
 from thirdparty.md2 import md2_hash
 from thirdparty.tiger import tiger
-from thirdparty.des import pydes
+
+import lib
 
 
 def mysql_hash(string, salt=None, front=False, back=False, **placeholder):


### PR DESCRIPTION
https://pep8.org/#imports

> Imports should be grouped in the following order:
> 1. standard library imports
> 2. related third party imports
> 3. local application/library specific imports
