### PR TITLE
Fix typos

### DIFF
--- a/bin/attacks/bruteforce/bf_attack.py
+++ b/bin/attacks/bruteforce/bf_attack.py
@@ -159,8 +159,8 @@ def bruteforce_main(verf_hash, algorithm=None, wordlist=None, salt=None, placeme
         results = hash_words(verf_hash, wordlist, algorithm, salt=salt, placement=placement, posx=posx)
         if results is None:
             LOGGER.warning("Unable to find a match using {}..".format(algorithm.upper()))
-            verifiy = prompt("Would you like to attempt to verify the hash type automatically and crack it", "y/N")
-            if verifiy.lower().startswith("y"):
+            verify = prompt("Would you like to attempt to verify the hash type automatically and crack it", "y/N")
+            if verify.lower().startswith("y"):
                 bruteforce_main(verf_hash, wordlist=wordlist, salt=salt, placement=placement, posx=posx, use_hex=use_hex)
             else:
                 LOGGER.warning("Unable to produce a result for given hash '{}' using {}.. Exiting..".format(

--- a/bin/verify_hashes/verify.py
+++ b/bin/verify_hashes/verify.py
@@ -47,7 +47,7 @@ HASH_TYPE_REGEX = {
     ],
     build_re(56, suffix=""): [
         ("sha224", "sha3_224"),
-        ("shein256(224)", "skein512(224)", "haval224")
+        ("skein256(224)", "skein512(224)", "haval224")
     ],
     build_re(40): [
         ("sha1", "ripemd160", "sha1(sha1(pass))", "sha1(sha1(sha1(pass)))"),

--- a/dagon.py
+++ b/dagon.py
@@ -234,9 +234,9 @@ if __name__ == '__main__':
                 elif opt.verifyHashList is not None:
                     with open(opt.verifyHashList) as hashes:
                         hashes.seek(0, 0)
-                        total_hahes = hashes.readlines()
-                        LOGGER.info("Found a total of {} hashes to verify..".format(len(total_hahes)))
-                        for h in total_hahes:
+                        total_hashes = hashes.readlines()
+                        LOGGER.info("Found a total of {} hashes to verify..".format(len(total_hashes)))
+                        for h in total_hashes:
                             print("")
                             LOGGER.info("Analyzing hash: '{}'".format(h.strip()))
                             if opt.runInBatchMode is True:

--- a/lib/algorithms/hashing_algs.py
+++ b/lib/algorithms/hashing_algs.py
@@ -45,7 +45,7 @@ def oracle_10g(string, salt=None, iv="\0"*8, padding="\0", key="0123456789ABCDEF
 
       > :param string: string to hash
       > :param iv: IV for the encryption
-      > :param padding: padding for the ecnryption
+      > :param padding: padding for the encryption
       > :param key: cipher key
       > :return: a hashed password
 

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -224,7 +224,7 @@ def random_salt_generator(use_string=False, use_number=False, length=None, warni
         length = int(length)
 
     if length > 12:
-        LOGGER.warning("It is recommenced to keep salt length under 12 {} for faster hashing..".format(salt_type))
+        LOGGER.warning("It is recommended to keep salt length under 12 {} for faster hashing..".format(salt_type))
     salt = []
     placement = ["front", "back"]
     if not use_string and use_number is True:


### PR DESCRIPTION
I noticed a couple typos, this PR fixes them. Also, I saw one other potential typo.

```python
("shein256(224)", "skein512(224)", "haval224")
   ^
```

I couldn't find any reference on google for `"shein"` hash but I could find `"skein"` hash

https://en.wikipedia.org/wiki/Skein_(hash_function)

I can easily push another commit and change the `h` to a `k` if that is what you want.
