### PR TITLE
fix for issue #26, using bcrypt in place of passlib

### DIFF
--- a/lib/algorithms/hashing_algs.py
+++ b/lib/algorithms/hashing_algs.py
@@ -6,7 +6,7 @@ import random
 import zlib
 
 import sha3
-from passlib.hash import bcrypt
+import bcrypt
 from thirdparty.blake import blake
 from thirdparty.des import pydes
 from thirdparty.md2 import md2_hash
@@ -86,23 +86,18 @@ def oracle_11g(string, salt=None, **placeholder):
     return "s:{}{}".format(obj.hexdigest(), salt.encode("hex")).upper()
 
 
-def blowfish_hash(string, salt=None, front=False, back=False, **placeholder):
+def blowfish(string, **placeholder):
     """
-      Create a Blowfish hash using passlib
+      Create a blowfish hash using bcrypt
 
       > :param string: string to generate a Blowfish hash from
       > :return: Blowfish hash
 
       Example:
-        >>> blowfish_hash("test")
-        $2b$12$9.uNMtjZD./9xGMD3QLHpen6WBSs8TmjmYSl5EGs4OS/zsUwmJivq
+        >>> blowfish("test")
+        $2b$12$fSX/dvlx3dJGkGYKSbBbLOTOhzqj8xQ2krOtu2QkHNeJiYTC0B/ji
     """
-    if salt is not None and front and not back:
-        return bcrypt.hash(salt + string)
-    elif salt is not None and back and not front:
-        return bcrypt.hash(string + salt)
-    else:
-        return bcrypt.hash(string)
+    return bcrypt.hashpw(string, bcrypt.gensalt())
 
 
 def postgres(string, salt=None, **placeholder):

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -32,7 +32,7 @@ LOGGER.setLevel(log_level)
 LOGGER.addHandler(stream)
 
 # Version number <major>.<minor>.<patch>.<git-commit>
-VERSION = "1.10.19.34"
+VERSION = "1.10.20.35"
 # Colors, green if stable, yellow if dev
 TYPE_COLORS = {"dev": 33, "stable": 92}
 # Version string, dev or stable release?
@@ -64,7 +64,7 @@ Home: {}
 FUNC_DICT = {
     "md2": md2, "md4": md4, "md5": md5, "half md5": half_md5, "md5(md5(pass)+md5(salt))": md5_pass_salt,
     "md5(md5(pass))": md5_md5_pass, "md5(salt+pass+salt)": md5_salt_pass_salt, "md5(md5(md5(pass)))": md5_md5_md5_pass,
-    "mysql": mysql_hash, "blowfish": blowfish_hash, "oracle 11g": oracle_11g, "oracle 10g": oracle_10g,
+    "mysql": mysql_hash, "blowfish": blowfish, "oracle 11g": oracle_11g, "oracle 10g": oracle_10g,
     "mssql 2005": mssql_2005, "postgresql": postgres, "mssql 2000": mssql_2000,
     "ripemd160": ripemd160,
     "blake224": blake224, "blake256": blake256, "blake384": blake384, "blake512": blake512,


### PR DESCRIPTION
- Deprecate `passlib`
- Use `bcrypt`'s `gensalt` method for now. This will work until I can figure out how the salt is generated by `bcrypt` and recreate it.
 - Bump version number 