### PR TITLE
add blake2 to 128 bits hash

### DIFF
--- a/bin/verify_hashes/verify.py
+++ b/bin/verify_hashes/verify.py
@@ -45,7 +45,7 @@ HASH_TYPE_REGEX = {
     build_re(128): [
         ("sha512", "whirlpool", "sha3_512"),
         ("salsa10", "salsa20", "skein512",
-         "skein1024(512)")
+         "skein1024(512)", "blake512")
     ],
     build_re(54, prefix="0x0100", suffix=""): [
         ("mssql 2005", None),


### PR DESCRIPTION
Currently blake2 hashes are not detected but they are in settings.py

```
➜ printf %s '' | b2sum
786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce  -

~ 
➜ dagon -v 786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce -L         
Dagon .. Advanced Hash Manipulation v1.15.37.60(dev)
Clone: https://github.com/ekultek/dagon.git


[*] Starting up at 11:58:07..

[11:58:07 INFO] Analyzing given hash: '786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce'...
---------------------------------------------------------------------------
[+] Most Likely Hash Type(s):
---------------------------------------------------------------------------
[+] SHA512
[+] WHIRLPOOL
[+] SHA3_512
---------------------------------------------------------------------------
[-] Least Likely Hash Type(s)(possibly not implemented):
---------------------------------------------------------------------------
[-] SALSA10 (not implemented yet)
[-] SALSA20 (not implemented yet)
[-] SKEIN512 (not implemented yet)
[-] SKEIN1024(512) (not implemented yet)
---------------------------------------------------------------------------

[*] Shutting down at 11:58:07..
```